### PR TITLE
refs #77 Fix link open command

### DIFF
--- a/src/components/timelines/status/LinkPreview.tsx
+++ b/src/components/timelines/status/LinkPreview.tsx
@@ -1,4 +1,4 @@
-import { shell } from '@tauri-apps/api'
+import { open } from '@tauri-apps/api/shell'
 import { Entity } from 'megalodon'
 import Image from 'next/image'
 import { FlexboxGrid, Panel } from 'rsuite'
@@ -11,7 +11,7 @@ type Props = {
 
 const LinkPreview: React.FC<Props> = props => {
   const onClick = () => {
-    shell.open(props.card.url)
+    open(props.card.url)
   }
 
   return (


### PR DESCRIPTION
To resolve an error: ReferenceError: window is not defined

fixes #77 

This code is the cause of 
```
error - ReferenceError: window is not defined
    at file:///run/media/h3poteto/ssd1/dev/src/github.com/h3poteto/fedistar/node_modules/@tauri-apps/api/chunk-QSWLDHGO.js:1:9678
    at ModuleJob.run (node:internal/modules/esm/module_job:193:25)
    at async Promise.all (index 0)
    at async ESMLoader.import (node:internal/modules/esm/loader:527:24)
    at async importModuleDynamicallyWrapper (node:internal/vm/module:438:15) {
  page: '/'
}
```