### PR TITLE
refs #490 Limit width of image tag in status

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -197,6 +197,17 @@
   cursor: pointer;
 }
 
+.status-body img {
+  max-width: 240px;
+}
+
+.status-body  blockquote {
+  padding-left: 10px;
+  border-left: 3px solid #9baec8;
+  color: #9baec8;
+  margin: 0;
+}
+
 .status-detail .status .body {
   cursor: default;
 }


### PR DESCRIPTION
And implement blockquote style

closes #490 
![Screenshot from 2023-03-05-20-35-21](https://user-images.githubusercontent.com/4631959/222958128-f6893316-e7ac-404f-ba67-c19136ec37bb.png)
![Screenshot from 2023-03-05-20-35-32](https://user-images.githubusercontent.com/4631959/222958137-9ed33d77-4433-438f-8845-8c2dccb92226.png)
