### PR TITLE
refs #793 Ignore when the notification does not have status field

### DIFF
--- a/src/components/timelines/notification/Notification.tsx
+++ b/src/components/timelines/notification/Notification.tsx
@@ -46,17 +46,21 @@ const notification = (props: Props) => {
     case 'status':
     case 'update':
     case 'emoji_reaction':
-      return (
-        <Reaction
-          server={props.server}
-          notification={props.notification}
-          updateStatus={props.updateStatus}
-          client={props.client}
-          openMedia={props.openMedia}
-          setTagDetail={(tag, serverId) => props.setTagDetail(tag, serverId, props.account?.id)}
-          setAccountDetail={account => props.setAccountDetail(account.id, props.server.id, props.account?.id)}
-        />
-      )
+      if (props.notification.status) {
+        return (
+          <Reaction
+            server={props.server}
+            notification={props.notification}
+            updateStatus={props.updateStatus}
+            client={props.client}
+            openMedia={props.openMedia}
+            setTagDetail={(tag, serverId) => props.setTagDetail(tag, serverId, props.account?.id)}
+            setAccountDetail={account => props.setAccountDetail(account.id, props.server.id, props.account?.id)}
+          />
+        )
+      } else {
+        return null
+      }
     case 'mention':
       if (props.notification.status) {
         return (


### PR DESCRIPTION
For example, if the status was deleted by the owner, the notification can't contain status field.

refs #793 