### PR TITLE
Disable swcMnify to fix bugs of minified code

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,7 +2,7 @@
 
 const nextConfig = {
   reactStrictMode: true,
-  swcMinify: true,
+  swcMinify: false,
   images: {
     unoptimized: true
   },


### PR DESCRIPTION
closes #1049 
It seems to be the same as this bug: https://github.com/vercel/next.js/issues/46887