### PR TITLE
Revert "chore(deps): update dependency node to v18.18.1"

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 rust 1.73.0
-nodejs 18.18.1
+nodejs 18.18.0


### PR DESCRIPTION
Reverts h3poteto/fedistar#1190
too early.