### PR TITLE
Revert "Update dependency rsuite to v5.50.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "react-icons": "^5.0.1",
     "react-intl": "^6.5.5",
     "react-virtuoso": "^4.6.2",
-    "rsuite": "5.50.0",
+    "rsuite": "5.48.1",
     "sanitize-html": "^2.11.0",
     "tauri-plugin-window-state-api": "github:tauri-apps/tauri-plugin-window-state#v1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ dependencies:
     specifier: ^4.6.2
     version: 4.6.2(react-dom@18.2.0)(react@18.2.0)
   rsuite:
-    specifier: 5.50.0
-    version: 5.50.0(react-dom@18.2.0)(react@18.2.0)
+    specifier: 5.48.1
+    version: 5.48.1(react-dom@18.2.0)(react@18.2.0)
   sanitize-html:
     specifier: ^2.11.0
     version: 2.11.0
@@ -4164,8 +4164,8 @@ packages:
       react-is: 17.0.2
     dev: false
 
-  /rsuite@5.50.0(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-pCRmQv78boznrhhLuhZbPb/SW3Swp2AR91qdBy3UnRMKLrVfVQfppsVIF7D5kyaGtDpl2hWBcK3LGSGCBHspHw==}
+  /rsuite@5.48.1(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-EnByYclx0zDpe5ndkpQAbJLA21tTG6pv9LnL02o4rngJ23ICROaF8rPwIJMXYq/6sKrHBUkjFlLX7OjrXbFQug==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'


### PR DESCRIPTION
Reverts h3poteto/fedistar#1290

![Screenshot from 2024-01-16-21-46-49](https://github.com/h3poteto/fedistar/assets/4631959/27cb7002-ed8b-4a98-8a62-452ddfee395b)
Caused of overflow.