### PR TITLE
Revert react-virtuoso to 4.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react-dom": "^18.2.0",
     "react-icons": "^5.0.1",
     "react-intl": "^6.6.2",
-    "react-virtuoso": "^4.7.0",
+    "react-virtuoso": "4.6.3",
     "rsuite": "5.54.0",
     "sanitize-html": "^2.12.1",
     "tauri-plugin-window-state-api": "github:tauri-apps/tauri-plugin-window-state#v1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ dependencies:
     specifier: ^6.6.2
     version: 6.6.2(react@18.2.0)(typescript@5.3.3)
   react-virtuoso:
-    specifier: ^4.7.0
-    version: 4.7.0(react-dom@18.2.0)(react@18.2.0)
+    specifier: 4.6.3
+    version: 4.6.3(react-dom@18.2.0)(react@18.2.0)
   rsuite:
     specifier: 5.54.0
     version: 5.54.0(react-dom@18.2.0)(react@18.2.0)
@@ -3988,8 +3988,8 @@ packages:
       react: 18.2.0
     dev: false
 
-  /react-virtuoso@4.7.0(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-cpgvI1rSOETGDMhqVAVDuH+XHbWO1uIGKv5I6l4CyC71xWYUeGrE5n7sgTZklROB4+Vbv85pcgfWloTlY48HGQ==}
+  /react-virtuoso@4.6.3(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-NcoSsf4B0OCx7U8i2s+VWe8b9e+FWzcN/5ly4hKjErynBzGONbWORZ1C5amUlWrPi6+HbUQ2PjnT4OpyQIpP9A==}
     engines: {node: '>=10'}
     peerDependencies:
       react: '>=16 || >=17 || >= 18'


### PR DESCRIPTION
Because it says an error
```
ResizeObserver loop completed with undelivered notifications.
```