### PR TITLE
Remove tauri-snap-packager

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "dev": "next dev -p 1420",
     "build": "next build",
     "tauri": "tauri",
-    "snap": "tauri-snap-packager",
     "lint": "eslint src --ext ts,tsx",
     "typecheck": "tsc -p . --noEmit",
     "test": "NODE_ENV=test jest -u --maxWorkers=3",
@@ -62,7 +61,6 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.23.0",
-    "@h3poteto/tauri-snap-packager": "0.2.1",
     "@tauri-apps/cli": "^2.2.7",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.13.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,9 +90,6 @@ importers:
       '@eslint/js':
         specifier: ^9.23.0
         version: 9.23.0
-      '@h3poteto/tauri-snap-packager':
-        specifier: 0.2.1
-        version: 0.2.1
       '@tauri-apps/cli':
         specifier: ^2.2.7
         version: 2.2.7
@@ -430,10 +427,6 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
-
-  '@h3poteto/tauri-snap-packager@0.2.1':
-    resolution: {integrity: sha512-TZstV34o+754TuF9Zs63cQ+bznhzpd85kdfJGW9DxgBHk4QO9fJ26C5b/yih2mibf1R3xlrSUD7GHiXsQ0VCGQ==}
-    hasBin: true
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -3492,10 +3485,6 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       typescript: 5.8.2
-
-  '@h3poteto/tauri-snap-packager@0.2.1':
-    dependencies:
-      js-yaml: 4.1.0
 
   '@humanfs/core@0.19.1': {}
 


### PR DESCRIPTION
Tauri v2 supports snap packaging, we don't need this library.